### PR TITLE
Update play and scalagen

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import javax.inject._
 import scala.util._
 import play.api._
 import play.api.mvc._
@@ -7,7 +8,8 @@ import play.api.data._
 import play.api.data.Forms._
 import models.Conversion
 
-object Application extends Controller {
+@Singleton
+class Application @Inject() extends Controller {
 
   val exampleCode = """
     |package hello;

--- a/app/models/Conversion.scala
+++ b/app/models/Conversion.scala
@@ -3,7 +3,7 @@ package models
 import scala.util.Try
 import java.io.ByteArrayInputStream
 import com.mysema.scalagen.Converter
-import japa.parser.JavaParser
+import com.github.javaparser.JavaParser
 
 object Conversion {
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,9 +5,10 @@ version := "1.0-SNAPSHOT"
 scalaVersion := "2.11.8"
 
 libraryDependencies ++= Seq(
-  "com.mysema.scalagen" %% "scalagen" % "0.3.2"
+  "com.mysema.scalagen" %% "scalagen" % "0.4.0"
 )
 
 resolvers += "Koofr Maven repo" at "http://koofr.github.com/repo/maven/"
+resolvers += Resolver.bintrayRepo("nightscape", "maven")
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)

--- a/build.sbt
+++ b/build.sbt
@@ -2,10 +2,12 @@ name := "javatoscala"
 
 version := "1.0-SNAPSHOT"
 
+scalaVersion := "2.11.8"
+
 libraryDependencies ++= Seq(
   "com.mysema.scalagen" %% "scalagen" % "0.3.2"
 )
 
 resolvers += "Koofr Maven repo" at "http://koofr.github.com/repo/maven/"
 
-play.Project.playScalaSettings
+lazy val root = (project in file(".")).enablePlugins(PlayScala)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,4 +5,4 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.2.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.10")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,3 +6,5 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.10")
+
+addSbtPlugin("me.lessis" %  "bintray-sbt" % "0.3.0")


### PR DESCRIPTION
Hi @koofr,

I've spent some time to update Scalagen with Java 8 and comment support.
The [corresponding PR](https://github.com/timowest/scalagen/pull/84) is not yet merged, but I've pre-released a build to Bintray.
This PR uses the new version and also updates Play, SBT and Scala to more recent versions.
I've tested the changes locally and successfully transformed Java 8 files including comments :grinning: 
